### PR TITLE
fixing typo Gendral Settings => General Settings

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -38,7 +38,7 @@ $wcw_is_float_value_yes		= get_option('wcw_is_float_value') == 1			? 'checked' :
 <div class = "wrap">
 <h1>WC Wallet Settings</h1>
 <form method="post">
-	<h3 class="title"><?php _e( 'Gendral Settings', WC_WALLET_TEXT ); ?></h3>
+	<h3 class="title"><?php _e( 'General Settings', WC_WALLET_TEXT ); ?></h3>
 	<table class="form-table">
 		<tr>
 			<th scope="row"><label for="wcw_payment_method"><?php _e( 'Credits Applicable If The Order Are In These Method', WC_WALLET_TEXT ); ?></label></th>

--- a/languages/wc-wallet.pot
+++ b/languages/wc-wallet.pot
@@ -93,7 +93,7 @@ msgid "You need to login to see your credits"
 msgstr ""
 
 #: includes/settings.php:41
-msgid "Gendral Settings"
+msgid "General Settings"
 msgstr ""
 
 #: includes/settings.php:44


### PR DESCRIPTION
i am who posted this on support forum https://wordpress.org/support/topic/found-some-typos-and-error-message/